### PR TITLE
Allow passing `release` parameter and `renovate.json` as file to replace last branch entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A simple CLI command to create a semantic-release minor bump pull request.
 ### via CLI
 
 ```bash
-npx @daraff/create-bump-pr \
+npx @livingdocs/create-bump-pr \
   --owner=<gh-owner> \
   --repo=<gh-repo> \
   --gh-token=<your-gh-token>

--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,7 @@ const argv = require('yargs')
     type: 'string'
   })
   .option('file', {
-    description: 'append an empty space space to this file (one needs a file diff to create a bump PR)',
+    description: 'append an empty space to this file (one needs a file diff to create a bump PR)',
     type: 'string',
     default: 'README.md'
   })
@@ -14,6 +14,11 @@ const argv = require('yargs')
     description: 'create a bump PR onto this branch',
     type: 'string',
     default: 'master'
+  })
+  .option('release', {
+    description: 'adds release to `baseBranches` in renovate.json',
+    type: 'string',
+    default: 'release-2023-01'
   })
   .help(false)
   .version(false)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@daraff/create-bump-pr",
+  "name": "@livingdocs/create-bump-pr",
   "version": "0.0.0-development",
   "description": "",
   "main": "index.js",
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DaRaFF/create-bump-pr.git"
+    "url": "git+https://github.com/livingdocsIO/create-bump-pr.git"
   },
   "devDependencies": {
     "semantic-release": "^15.12.0",
@@ -29,7 +29,7 @@
     "access": "public"
   },
   "bugs": {
-    "url": "https://github.com/DaRaFF/create-bump-pr/issues"
+    "url": "https://github.com/livingdocsIO/create-bump-pr/issues"
   },
-  "homepage": "https://github.com/DaRaFF/create-bump-pr#readme"
+  "homepage": "https://github.com/livingdocsIO/create-bump-pr#readme"
 }


### PR DESCRIPTION
This will remove one step in the release process steps.